### PR TITLE
Add support for OSXFUSE

### DIFF
--- a/fuse.py
+++ b/fuse.py
@@ -28,7 +28,7 @@ _system = system()
 _machine = machine()
 
 if _system == 'Darwin':
-    _libfuse_path = find_library('fuse4x') or find_library('fuse')
+    _libfuse_path = find_library('fuse4x') or find_library('fuse') or find_library('osxfuse')
 else:
     _libfuse_path = find_library('fuse')
 if not _libfuse_path:


### PR DESCRIPTION
OSXFUSE is also looked for as MacFUSE and Fuse4X are no longer supported.
